### PR TITLE
Avoid binding callbacks to radio

### DIFF
--- a/dist/fluxo.js
+++ b/dist/fluxo.js
@@ -949,7 +949,7 @@ var Radio = (function () {
       for (var i = 0, l = events.length; i < l; i++) {
         var eventName = events[i],
             changeEventToken = eventName,
-            canceler = this.subscribe(changeEventToken, callback.bind(this));
+            canceler = this.subscribe(changeEventToken, callback);
 
         cancelers.push(canceler);
       }

--- a/src/fluxo.radio.js
+++ b/src/fluxo.radio.js
@@ -43,7 +43,7 @@ class Radio {
     for (let i = 0, l = events.length; i < l; i++) {
       let eventName = events[i],
           changeEventToken = eventName,
-          canceler = this.subscribe(changeEventToken, callback.bind(this));
+          canceler = this.subscribe(changeEventToken, callback);
 
       cancelers.push(canceler);
     }


### PR DESCRIPTION
There is no need for that since computed already binds it to the object
store instance.
